### PR TITLE
Adiciona suporte ao PHP 8.4

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-PHP_VERSION=8.2
+PHP_VERSION=8.4
 DOMAIN=mangeto.local
 USERNAME=systemuser
 HOST_OS=linux

--- a/images/php/Dockerfile-8.4
+++ b/images/php/Dockerfile-8.4
@@ -1,0 +1,30 @@
+FROM luiztucillo/php84
+
+ENV PHP_CONFIG_PATH=/etc/php/8.4
+
+ARG username
+ENV USERNAME=$username
+
+ARG host_os
+ENV HOST_OS=$host_os
+
+ARG domain
+ENV DOMAIN=$domain
+
+COPY conf/xdebug-${HOST_OS}.ini $PHP_CONFIG_PATH/mods-available/xdebug.ini
+
+RUN useradd -m $USERNAME \
+    && chown -R $USERNAME:$USERNAME /var/www/html
+
+RUN echo "user = $USERNAME" >> $PHP_CONFIG_PATH/fpm/php-fpm.conf \
+    && echo "group = $USERNAME" >> $PHP_CONFIG_PATH/fpm/php-fpm.conf
+
+RUN mkdir /home/$USERNAME/.composer \
+    && chown -R $USERNAME:$USERNAME /home/$USERNAME/.composer
+
+RUN composer self-update
+
+# Make sure the volume mount point is empty
+USER $USERNAME
+RUN rm -rf /var/www/html/*
+WORKDIR /var/www/html


### PR DESCRIPTION
# Adiciona suporte ao PHP 8.4

## Descrição
Este PR adiciona suporte ao PHP 8.4 no ambiente Docker do Magento, incluindo:
- Novo Dockerfile para PHP 8.4
- Atualização do arquivo `.env.sample` para usar PHP 8.4 como versão padrão

## Alterações
- Criado novo arquivo `images/php/Dockerfile-8.4` com configurações específicas para PHP 8.4
- Atualizado `.env.sample` para usar PHP 8.4 como versão padrão
- Configurado suporte a Xdebug
- Configurado usuário e permissões adequadas
- Configurado Composer

## Testes
- [x] Verificar se o ambiente inicia corretamente com PHP 8.4
- [x] Testar instalação do Magento com PHP 8.4
- [x] Verificar se o Xdebug está funcionando corretamente
- [x] Confirmar que as permissões de arquivos estão corretas

## Notas Adicionais
- Esta alteração mantém a compatibilidade com as versões anteriores do PHP
- O Dockerfile segue o mesmo padrão dos outros arquivos de configuração do PHP